### PR TITLE
Remove duplicate output bundle and dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,5 +25,6 @@
   "devDependencies": {
     "bunchee": "^6.5.4",
     "typescript": "^5.8.3"
-  }
+  },
+  "packageManager": "pnpm@9.15.9"
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "A library for generating safe, legit and random URL-safe IDs",
   "type": "module",
   "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "files": [
     "dist",
@@ -26,8 +25,5 @@
   "devDependencies": {
     "bunchee": "^6.5.4",
     "typescript": "^5.8.3"
-  },
-  "dependencies": {
-    "@swc/helpers": "^0.5.17"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,10 +7,6 @@ settings:
 importers:
 
   .:
-    dependencies:
-      '@swc/helpers':
-        specifier: ^0.5.17
-        version: 0.5.17
     devDependencies:
       bunchee:
         specifier: ^6.5.4


### PR DESCRIPTION
* In ES module, `main: <name>.js` is enough, we don't have to duplicate `module` field with a different extension. It will be the exact same content
* The `@swc/helpers` is only needed when you have special transforms. The output target is ES2022, so we don't require extra helpers. Hence remove this dep
* Add `packageManager` field in case it will have unexpected change when pnpm versions are mismatched on other machines